### PR TITLE
docs: make rst2pdf optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,12 +98,16 @@ Then do a pip install from your working copy::
 Building Documentation
 ======================
 Documentation for pastream can be easily generated in a wide variety of formats
-using Sphinx. Just follow the steps below. Note that this only works with
-python 2 ATM since rst2pdf does not yet officially support python 3.
+using Sphinx. Just follow the steps below.
 
-Checkout the repository::
+Checkout the repository and cd into it::
 
     $ git clone --recursive http://github.com/tgarc/pastream
+    $ cd pastream
+
+Install documentation dependencies (while inside the repository root)
+
+    $ pip install .[docs]
 
 Then use the included makefile/make.bat to generate documentation. (Here we
 output to the html format)::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,6 @@
 # import sys
 # sys.path.insert(0, '/home/tdos/dev/pastream')
 
-
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -37,8 +36,19 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.napoleon',
               'sphinx.ext.intersphinx',
               'sphinxarg.ext',
-              'rst2pdf.pdfbuilder'
 ]
+
+
+import sys
+if sys.version_info.major < 3:
+    try:
+        import rst2pdf
+    except ImportError:
+        pass
+    else:
+        del rst2pdf
+        extensions.append('rst2pdf.pdfbuilder')
+del sys    
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name='pastream',
       extras_require={
           'tests': test_deps,
           'examples': ['numpy', 'matplotlib'],
-          'docs': ['sphinx', 'sphinx_rtd_theme', 'rst2pdf', 'sphinx-argparse']
+          'docs': ['sphinx', 'sphinx_rtd_theme', 'sphinx-argparse']
       },
       classifiers=[
           'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
- fix the docs/conf.py so rst2pdf is completely optional

- remove note about python2 only in README